### PR TITLE
Support for Errbot 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ streamed from Stackstorm to Errbot.  The Stackstorm stream url must be supplied 
 to use SSE.  The SSE configuration is complementry to the webhook method and both must be enabled
 for full chatops support between Stackstorm and Errbot.
 
+
+## Stackstorm Chatops pack configuration.
+
+StackStorm's chatop pack https://github.com/StackStorm/st2/tree/master/contrib/chatops is required 
+to be installed and a notify rule file added to the pack.  The notify rule must be placed in 
+`/<stackstorm installation>/packs/chatops/rules`.  The rule file `notify_errbot.yaml` can be found 
+in this repository under `contrib/stackstorm-chatops`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation of the err-stackstorm plugin is performed from within a running err
 
 The below command will install the plugin.
 ```
-!repos install https://github.com/nzlosh/err-stackstorm.git
+!repos install https://github.com/fmnisme/err-stackstorm.git
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ The below command will install the plugin.
 
 ## Requirements
 The plugin has been developed and tested against the below software.  For optimal operation it is recommended to use the following versions:
- - Python 3.4
- - errbot 4.3
- - stackstorm client 2.2
 
+plugin tag (version) | Python | Errbot | StackStorm client
+--- | --- | --- | ---
+1.2 | 3.4 | 5.0 | 2.2
+1.1 | 3.4 | 4.3 | 2.2
+1.0 | 2.7 | 3.x | 2.1
 
 ## Configuration
 Edit the `config.py` configuration file which is used to describe how the plugin will communicate with Stackstorm's API and authentication end points.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The below command will install the plugin.
 
 ## Requirements
 The plugin has been developed and tested against the below software.  For optimal operation it is recommended to use the following versions:
- - Python >3.4
- - errbot >4.3
- - stackstorm client >2.2
+ - Python 3.4
+ - errbot 4.3
+ - stackstorm client 2.2
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation of the err-stackstorm plugin is performed from within a running err
 
 The below command will install the plugin.
 ```
-!repos install https://github.com/fmnisme/err-stackstorm.git
+!repos install https://github.com/nzlosh/err-stackstorm.git
 ```
 
 ## Requirements

--- a/contrib/stackstorm-chatops/rules/notify_errbot.yaml
+++ b/contrib/stackstorm-chatops/rules/notify_errbot.yaml
@@ -1,5 +1,5 @@
 ---
-name: "notify"
+name: "notify-errbot"
 pack: "chatops"
 enabled: true
 description: "Notification rule to send results of action executions to stream for chatops"

--- a/contrib/stackstorm-chatops/rules/notify_errbot.yaml
+++ b/contrib/stackstorm-chatops/rules/notify_errbot.yaml
@@ -1,0 +1,17 @@
+---
+name: "notify"
+pack: "chatops"
+enabled: true
+description: "Notification rule to send results of action executions to stream for chatops"
+trigger:
+  type: "core.st2.generic.notifytrigger"
+criteria:
+  trigger.route:
+    pattern: "errbot"
+    type: "equals"
+action:
+  ref: chatops.post_result
+  parameters:
+    channel: "{{trigger.data.source_channel}}"
+    user: "{{trigger.data.user}}"
+    execution_id: "{{trigger.execution_id}}"

--- a/st2.py
+++ b/st2.py
@@ -100,7 +100,7 @@ class St2(BotPlugin):
                 result = "st2 command '{}' is disabled.".format(msg.body)
         else:
             result = "st2 command '{}' not found.  Check help with {}st2help"
-            result = result.format(user_command, self.st2config.bot_prefix)
+            result = result.format(msg.body, self.st2config.bot_prefix)
         return result
 
     @botcmd
@@ -138,7 +138,12 @@ class St2(BotPlugin):
                                                                                 channel,
                                                                                 extra))
         if user is not None:
-            target_id = self.build_identifier(user)
+            user_id = self.build_identifier(user)
+
+        if channel is not None:
+            channel_id = self.build_identifier(channel)
+
+        if whisper is True:
+            self.send(user_id, message)
         else:
-            target_id = self.build_identifier(channel)
-        self.send(target_id, message)
+            self.send(channel_id, message)

--- a/st2.py
+++ b/st2.py
@@ -32,8 +32,8 @@ class St2(BotPlugin):
     Stackstorm plugin for authentication and Action Alias execution.
     Try !st2help for action alias help.
     """
-    def __init__(self, bot):
-        super(St2, self).__init__(bot)
+    def __init__(self, bot, name):
+        super(St2, self).__init__(bot, name)
 
         self.st2config = St2Config(self.bot_config)
         self.st2api = St2PluginAPI(self.st2config)

--- a/st2pluginapi.py
+++ b/st2pluginapi.py
@@ -34,6 +34,7 @@ class St2PluginAPI(object):
 
     def match(self, text):
         auth_kwargs = self.st2auth.auth_method("st2client")
+        auth_kwargs['debug'] = False
 
         LOG.info("Create st2 client with {} {} {}".format(self.st2config.base_url,
                                                           self.st2config.api_url,
@@ -176,11 +177,13 @@ class St2PluginAPI(object):
         execution.name = action_alias.name
         execution.format = representation
         execution.command = msg.body
-        execution.source_channel = str(msg.frm)
         if msg.is_direct == False:
-            execution.notification_channel = str(msg.frm)
-        else:
             execution.notification_channel = str(msg.to)
+            execution.source_channel = str(msg.to)
+        else:
+            execution.notification_channel = str(msg.frm)
+            execution.source_channel = str(msg.frm)
+
         execution.notification_route = 'errbot'
         execution.user = str(msg.frm)
 
@@ -196,8 +199,12 @@ class St2PluginAPI(object):
         execution = action_exec_mgr.create(execution)
 
         LOG.info("AFTER {}{}".format(type(execution), dir(execution)))
-        LOG.info("AFTER {}{}".format(execution.execution, execution.message))
-        return " ".join([execution.message])
+        try:
+            ret_msg = execution.message
+            LOG.info("AFTER {}{}".format(execution.execution, execution.message))
+        except AttributeError as e:
+            ret_msg = "Something is happening ... "
+        return ret_msg # " ".join([execution.message])
 
     def st2stream_listener(self, callback=None):
         """

--- a/st2pluginauth.py
+++ b/st2pluginauth.py
@@ -35,7 +35,7 @@ class St2PluginAuth(object):
         Return the appropriate authentication method to use with an API key or User token.
         """
         client = {
-            "requests": {"api_key": 'St2-Api-Key:', "token": 'X-Auth-Token'},
+            "requests": {"api_key": 'St2-Api-Key', "token": 'X-Auth-Token'},
             "st2client": {"api_key": 'api_key', "token": 'token'},
             "st2": {"api_key": "--api-key", "token": "--token"}
         }


### PR DESCRIPTION
Patch to support Errbot 5.0 which was released as stable.

The documentation has been updated with a table that shows which plugin tag (version) supports a combination of Errbot, StackStorm client and Python versions.  Since I can't push tags upstream, I've listed the tag with its commit id so you'll be able to add it.

commit e4f677580cfc9c28b35a461138893577a75bd7a0
Refs: [1.2]
commit 1ed05fd3c897112cab56b47193590b2d81391af4
Refs: [1.1]
commit 0dd24ecdd669513e30f80c4ac318d7bce2ac8172
Refs: [1.0]

I hope that makes sense.