### PR TITLE
Bump st2client to version 2.5 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-st2client>=2.2.0
+st2client>=2.5.0
 sseclient-py


### PR DESCRIPTION
st2client v2.5 is required for StackStorm installations using version 2.5