### PR TITLE
README: fix Errbot configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ If you followed the Errbot setup documentation this file will have been created 
 STACKSTORM = {
     'base_url': 'https://stackstorm.example.com',
     'auth_url': 'https://stackstorm.example.com/auth',
-    'api_url': 'https://stackstorm.example.com/api/v1',
-    'stream_url': 'https://stackstorm.example.com/stream/v1',
+    'api_url': 'https://stackstorm.example.com/api',
+    'stream_url': 'https://stackstorm.example.com/stream/v1/stream',
     'api_version': 'v1',
     'verify_cert': True,
     'api_auth': {
@@ -86,6 +86,7 @@ STACKSTORM = {
     'timer_update': 900, #  Unit: second.  Interval for Errbot to refresh to list of available action aliases.
 }
 ```
+
 Option | Description
 --- | ---
 `base_url` | StackStorm's base url.  (deprecated)


### PR DESCRIPTION
This PR actualizes example snippet to add to Errbot's `config.py` file.

1. It seems that `api_url` and `api_version` values are concatenated to get full URL of ST2 API endpoint.
   So, trailing `v1` is unnecessary for `api_url`. Errbot can't connect to StackStorm otherwise.
2. According to latest [API docs](https://api.stackstorm.com/stream/v1/stream/), `stream_url` should be different. And then it starts working.

Thank you @fmnisme and @nzlosh for this awesome plugin and comprehensive documentation!
