### PR TITLE
README: mention WebserverConfiguration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,22 +133,23 @@ _API Key_ support has been included since StackStorm v2.0.  When an _API Key_ is
 
 Errbot has a built in web server which is configured and enabled through the bots admin chat interface.  The StackStorm plugin is written to listen for StackStorm's chatops messages and delivers them to the attached chat back-end.
 
-To configure Errbot's web server plugin, the command below can be sent to Errbot.
+To configure Errbot's web server plugin, the command below can be sent to Errbot:
 ```
-!plugin config Webserver {'HOST': '0.0.0.0',
-'PORT': 8888,
-'SSL': {'certificate': '',
-'enabled': False,
-'host': '0.0.0.0',
-'key': '',
-'port': 8889}}
+!plugin config Webserver {'HOST': '0.0.0.0', 'PORT': 3141,
+'SSL': {'enabled': False, 'host': '0.0.0.0', 'port': 3142, 'certificate': '', 'key': ''}}
 ```
+
 **NOTE:** _The variables must be adjusted to match the operating environment in which Errbot is running.  See Errbot documentation for further configuration information._
 
-Enable to web server plugin.
+The configuration above is only applied for the current runtime and will not
+persist after the errbot process being restarted. Making the configuration
+change permanent is as simple as installing a special plugin:
 ```
-!plugin activate Webserver
+!repos install https://github.com/tkit/errbot-plugin-webserverconfiguration
 ```
+The configuration command from above is not required prior to installing this
+plugin.
+
 In production environments it may be desirable to place a reverse-proxy like nginx in front of errbot.
 
 ## Send notifications to Errbot from StackStorm using Server-Side Events (SSE) <a name="ServerSideEvents"></a>


### PR DESCRIPTION
This PR adds suggestion to use simple but [cool plugin](https://github.com/tkit/errbot-plugin-webserverconfiguration) to make `Webserver` plugin configuration persistent.

I've discovered that `Webserver` plugin being always un-configured and deactivated after I restart the Errbot. I remember it wasn't like that in my previous setup (or earlier version of Err?).
I'm not sure is that by design or so, and I haven't found any issues or docs related to how actually "save" configuration changes.

Then I stumbled at **WebserverConfiguration** plugin. It just does exactly what I need, always configure the `Webserver` with default options. I decided it would be worth to mention it here, because probably not only me could run into this issue.

Also I have corrected the `Webserver` configuration command to use [default plugin configuration](http://errbot.io/en/latest/_modules/errbot/core_plugins/webserver.html).